### PR TITLE
ZI-normal -  relecture basique Julien

### DIFF
--- a/R/zi_normal.R
+++ b/R/zi_normal.R
@@ -156,8 +156,8 @@ zi_normal <- R6::R6Class(
         rho     <- check_one_boundary(check_zero_boundary(self$zeros * t((1 / (1 + kfactor * gamma)))))
 
         ## M step
-        R     <- t(self$Y - self$X %*% B)
-        dm1   <- 1 / check_zero_boundary(rowSums(t(1 - rho) * R^2)  / rowSums(1 - t(rho)))
+        R     <- self$Y - self$X %*% B
+        dm1   <- 1 / check_zero_boundary(colSums((1 - rho) * R^2)  / colSums(1 - rho))
         kappa <- colMeans(rho)
         B     <- private$zi_normal_optim_B(B, dm1, rho, kappa)
 

--- a/R/zi_normal.R
+++ b/R/zi_normal.R
@@ -20,6 +20,8 @@ zi_normal <- R6::R6Class(
     Y  = NULL,
     #' @field X the matrix of covariates
     X = NULL,
+    #' @field zeros indicator matrix of zeros in Y
+    zeros = NULL,
     #' @field niter number of iterations in model optimization
     niter = NULL,
     #' @field threshold loglikelihood threshold under which optimization stops
@@ -40,6 +42,7 @@ zi_normal <- R6::R6Class(
       }
       self$Y <- Y
       self$X <- X
+      self$zeros <- 1 * (Y == 0)
       self$niter <- niter
       self$threshold <- threshold
       private$n <- nrow(Y)
@@ -66,9 +69,7 @@ zi_normal <- R6::R6Class(
     #' @description calls EM optimization and updates relevant fields
     #' @return optimizes the model and updates its parameters
     optimize = function() {
-      optim_out <- do.call(private$zi_normal_EM, list(Y = self$Y, X = self$X,
-                                                      niter = self$niter,
-                                                      threshold = self$threshold))
+      optim_out <- private$zi_normal_EM(niter = self$niter, threshold = self$threshold)
       do.call(self$update, optim_out)
     },
 
@@ -82,7 +83,7 @@ zi_normal <- R6::R6Class(
 
     #' @description plots log-likelihood values during model optimization
     plot_loglik = function(){
-      plot(1:length(private$ll_list), private$ll_list)
+      plot(1:length(private$ll_list), private$ll_list, type = 'b')
     }
   ),
 
@@ -99,89 +100,73 @@ zi_normal <- R6::R6Class(
     rho     = NA,   # posterior probabilities of zero-inflation
     ll_list = NA,   # list of log-likelihood values during optimization
 
-    zi_normal_loglik  = function(Y, X, B, dm1, rho, kappa) {
-      ## problem dimensions
-      n   <- nrow(Y); p <- ncol(Y); d <- ncol(X)
+    zi_normal_loglik  = function(B, dm1, rho, kappa) {
 
-      ## useful matrices
-      Dm1 <- diag(dm1)
-      indicator <- Y == 0
-
-      J <- sum(indicator * rho)
-      J <- J - .5 * sum((1 - rho) * ((Y - X %*% B)^2 %*% Dm1))
-      J <- J - .5 * sum((1 - rho) %*% (-log(diag(Dm1)) + log(2 * pi)))
-      J <- J + sum((indicator * rho) %*% log(kappa))
-      J <- J + sum((1 - indicator * rho) %*% log(1 - kappa))
+      J <- sum(self$zeros * rho)
+      J <- J - .5 * sum((1 - rho) * t(t(self$Y - self$X %*% B)^2 * dm1))
+      J <- J - .5 * sum((1 - rho) %*% (-log(dm1) + log(2 * pi)))
+      J <- J + sum((self$zeros * rho) %*% log(kappa))
+      J <- J + sum((1 - self$zeros * rho) %*% log(1 - kappa))
       J
     },
 
+    zi_normal_obj_grad_B = function(B_vec, dm1, rho) {
+      YmXB <- self$Y - self$X %*% matrix(B_vec, nrow = private$d, ncol = private$p)
 
-    zi_normal_gradB   = function(Y, X, B, dm1, rho) {
-      Dm1    <- diag(dm1)
-      grad <- t(X)  %*% ((1 - rho) * (Y - X %*% B)) %*% Dm1
-      grad
+      ## A %*% diag(d) = t(t(A) * d)
+      grad <- -t(t(crossprod(self$X, (1 - rho) * YmXB)) * dm1)
+      obj <- .5 * sum((1 - rho) * t(t(YmXB^2) * dm1))
+
+      res <- list("objective" = obj, "gradient"  = grad)
+      res
     },
 
-    zi_normal_optim_B = function(B0, Y, X, dm1,  rho, kappa) {
+    zi_normal_optim_B = function(B0, dm1,  rho, kappa) {
       B0_vec <- as.vector(B0)
       res <- nloptr::nloptr(
         x0 = B0_vec,
-        eval_f = function(B_vec) {
-          B <- matrix(B_vec, nrow = ncol(X), ncol = ncol(Y))
-          Dm1 <- diag(dm1)
-          YmXB <- Y - X %*% B
-          list("objective" = .5 * sum((1 - rho) * (YmXB^2 %*% Dm1)),
-               "gradient"  = -crossprod(X, (1 - rho) * YmXB) %*% Dm1)
-        },
+        eval_f = private$zi_normal_obj_grad_B,
         opts = list(
           algorithm = "NLOPT_LD_LBFGS",
           xtol_rel = 1e-6,
           maxeval = 1000
-        )
+        ),
+        dm1 = dm1,
+        rho = rho
       )
-      newB <- matrix(res$solution, nrow = ncol(X), ncol = ncol(Y))
+      newB <- matrix(res$solution, nrow = private$d, ncol = private$p)
       newB
     },
 
-    zi_normal_EM = function(Y, X, niter, threshold) {
-      ## problem dimensions
-      n <- nrow(Y); p <- ncol(Y); d <- ncol(X)
-
-      ## useful matrices
-      indicator <- 1*(Y == 0)
+    zi_normal_EM = function(niter, threshold) {
 
       ## Initialization
-      rho   <- check_one_boundary(check_zero_boundary(indicator))
-      kappa <- check_one_boundary(check_zero_boundary(colMeans(indicator)))
-      B     <- solve(crossprod(X, X)) %*% t(X) %*% Y
-      R     <- t(Y - X %*% B)
-      Ddiag <- check_one_boundary(check_zero_boundary(diag(cov(t(R)))))
-      D     <- diag(Ddiag)
-      dm1   <- 1 / Ddiag
-      Dm1   <- diag(dm1)
+      rho   <- check_one_boundary(check_zero_boundary(self$zeros))
+      kappa <- check_one_boundary(check_zero_boundary(colMeans(self$zeros)))
+      B     <- solve(crossprod(self$X)) %*% crossprod(self$X, self$Y)
+      dm1   <- 1 / check_one_boundary(check_zero_boundary(diag(cov(self$Y - self$X %*% B))))
 
-      ll_list <- private$zi_normal_loglik(Y, X, B, dm1, rho, kappa)
+      ll_list <- private$zi_normal_loglik(B, dm1, rho, kappa)
 
       for (h in 2:niter) {
+
         ## E step
-        kfactor <- diag((1 - kappa) / kappa)
-        gamma   <- 1 / sqrt(2 * pi) * sqrt(Dm1) %*% exp(- .5 * Dm1 %*%
-                                                          crossprod(B, t(X))^2)
-        rho     <- check_one_boundary(check_zero_boundary(indicator * t((1 / (1 + kfactor %*% gamma)))))
+        kfactor <- (1 - kappa) / kappa
+        gamma   <- 1 / sqrt(2 * pi) * sqrt(dm1) * exp(- .5 * dm1 * t(X %*% B)^2)
+        rho     <- check_one_boundary(check_zero_boundary(self$zeros * t((1 / (1 + kfactor * gamma)))))
 
         ## M step
-        R     <- t(Y - X %*% B)
-        Ddiag <- check_zero_boundary(rowSums(t(1 - rho) * R^2)  / rowSums(1 - t(rho)))
-        dm1   <- 1 / Ddiag
-        Dm1   <- diag(dm1)
+        R     <- t(self$Y - self$X %*% B)
+        dm1   <- 1 / check_zero_boundary(rowSums(t(1 - rho) * R^2)  / rowSums(1 - t(rho)))
         kappa <- colMeans(rho)
-        B     <- private$zi_normal_optim_B(B, Y, X, dm1, rho, kappa)
+        B     <- private$zi_normal_optim_B(B, dm1, rho, kappa)
 
-        loglik <- private$zi_normal_loglik(Y, X, B, dm1, rho, kappa)
+        ## Assessing convergence
+        loglik <- private$zi_normal_loglik(B, dm1, rho, kappa)
         ll_list <- c(ll_list, loglik)
-
         if (abs(ll_list[h] - ll_list[h - 1]) < threshold)
           break
+
       }
       list(B = B, dm1 = dm1, kappa = kappa, rho = rho, ll_list = ll_list)
     }

--- a/R/zi_normal.R
+++ b/R/zi_normal.R
@@ -105,11 +105,10 @@ zi_normal <- R6::R6Class(
 
       ## useful matrices
       Dm1 <- diag(dm1)
-      indicator <- matrix(sapply(Y, function(x) ifelse(x == 0, 1, 0)),
-                                nrow = nrow(Y), ncol = ncol(Y))
+      indicator <- Y == 0
 
       J <- sum(indicator * rho)
-      J <- J - .5 * sum((1 - rho) * ((Y - X %*%B )^2 %*% Dm1))
+      J <- J - .5 * sum((1 - rho) * ((Y - X %*%B)^2 %*% Dm1))
       J <- J - .5 * sum((1 - rho) %*% (-log(diag(Dm1)) + log(2 * pi)))
       J <- J + sum((indicator * rho) %*% log(kappa))
       J <- J + sum((1 - indicator * rho) %*% log(1 - kappa))
@@ -129,12 +128,11 @@ zi_normal <- R6::R6Class(
         x0 = B0_vec,
         eval_f = function(B_vec) {
           B <- matrix(B_vec, nrow = ncol(X), ncol = ncol(Y))
-          - private$zi_normal_loglik(Y, X, B, dm1, rho, kappa)
-        } ,
-        eval_grad_f = function(B_vec) {
-          B <- matrix(B_vec, nrow = ncol(X), ncol = ncol(Y))
-          - private$zi_normal_gradB(Y, X,  B, dm1, rho)
-        } ,
+          Dm1 <- diag(dm1)
+          YmXB <- Y - X %*%B
+          list("objective" = .5 * sum((1 - rho) * (YmXB^2 %*% Dm1)),
+               "gradient"  = -crossprod(X, (1 - rho) * YmXB) %*% Dm1)
+        },
         opts = list(
           algorithm = "NLOPT_LD_LBFGS",
           xtol_rel = 1e-6,
@@ -150,8 +148,8 @@ zi_normal <- R6::R6Class(
       n <- nrow(Y); p <- ncol(Y); d <- ncol(X)
 
       ## useful matrices
-      indicator <- matrix(sapply(Y, function(x) ifelse(x == 0, 1, 0)),
-                          nrow = nrow(Y), ncol = ncol(Y))
+      indicator <- 1*(Y == 0)
+
       ## Initialization
       rho   <- check_one_boundary(check_zero_boundary(indicator))
       kappa <- check_one_boundary(check_zero_boundary(colMeans(indicator)))

--- a/R/zi_normal.R
+++ b/R/zi_normal.R
@@ -108,7 +108,7 @@ zi_normal <- R6::R6Class(
       indicator <- Y == 0
 
       J <- sum(indicator * rho)
-      J <- J - .5 * sum((1 - rho) * ((Y - X %*%B)^2 %*% Dm1))
+      J <- J - .5 * sum((1 - rho) * ((Y - X %*% B)^2 %*% Dm1))
       J <- J - .5 * sum((1 - rho) %*% (-log(diag(Dm1)) + log(2 * pi)))
       J <- J + sum((indicator * rho) %*% log(kappa))
       J <- J + sum((1 - indicator * rho) %*% log(1 - kappa))
@@ -129,7 +129,7 @@ zi_normal <- R6::R6Class(
         eval_f = function(B_vec) {
           B <- matrix(B_vec, nrow = ncol(X), ncol = ncol(Y))
           Dm1 <- diag(dm1)
-          YmXB <- Y - X %*%B
+          YmXB <- Y - X %*% B
           list("objective" = .5 * sum((1 - rho) * (YmXB^2 %*% Dm1)),
                "gradient"  = -crossprod(X, (1 - rho) * YmXB) %*% Dm1)
         },

--- a/tests/testthat/test-normal_zi.R
+++ b/tests/testthat/test-normal_zi.R
@@ -3,10 +3,10 @@
 n     = 200
 p     = 50
 d     = 2
-minB  = -1
-maxB  = 1
-minX  = rep(-50, d)
-maxX  = rep(50, d)
+minB  = 2
+maxB  = 4
+minX  = rep(0,  d)
+maxX  = rep(10, d)
 minD  = 0.2
 maxD  = 3
 minKappa = 0.1


### PR DESCRIPTION
- Quelques simplification dans les appels aux fonctions
- Suppression de variables inutiles
- A %*% diag(d) = t(t(A) * d) (évite de strocker une matrice inutilement, et gain d'un ordre de grandeur en complexité)