### PR TITLE
added the possibility to change sparsity and optimize afterwards

### DIFF
--- a/R/NB_class.R
+++ b/R/NB_class.R
@@ -241,9 +241,24 @@ NB <- R6::R6Class(
     #' @field model_par a list with the matrices of the model parameters: B (covariates), dm1 (species variance), OmegaQ (groups precision matrix))
     model_par = function(value) c(super$model_par, list(OmegaQ = private$OmegaQ)),
     #' @field sparsity (overall sparsity parameter)
-    sparsity = function(value) private$sparsity_,
+    sparsity = function(value) {
+      if (missing(value)) {
+        private$sparsity_
+      } else {
+        stopifnot("must be a positive scale" = value >= 0)
+        private$sparsity_ <- value
+      }
+    },
     #' @field sparsity_weights (weights associated to each pair of groups)
-    sparsity_weights = function(value) private$weights,
+    sparsity_weights = function(value) {
+      if (missing(value)) {
+        private$weights
+      } else {
+        stopifnot("must be a Q x Q matrix" =
+          all(is.matrix(value), nrow(value) == ncol(value), ncol(value) == self$Q))
+        private$weights <- value
+      }
+    },
     #' @field sparsity_term (sparsity_term term in log-likelihood due to sparsity)
     sparsity_term = function(value) self$sparsity * sum(abs(self$sparsity_weights * private$OmegaQ)),
     #' @field loglik (or its variational lower bound)

--- a/tests/testthat/test-NB_fixed_Q.R
+++ b/tests/testthat/test-NB_fixed_Q.R
@@ -17,9 +17,17 @@ test_that("normal block with diagonal residual covariance and unknown clusters",
   model$optimize()
   expect_gt(model$loglik, -2620)
   expect_lt(Metrics::rmse(model$fitted, Y), 1)
+  expect_equal(model$sparsity, 0)
   expect_equal(matching_group_scores(model$clustering, get_clusters(C)), 1)
-  model <- NB_fixed_Q$new(data, Q, sparsity = 0.05)
+
+  model_sparse <- NB_fixed_Q$new(data, Q, sparsity = 0.05)
+  model_sparse$optimize()
+  expect_equal(model_sparse$sparsity, 0.05)
+
+  model$sparsity <- 0.05
+  expect_equal(model$sparsity, 0.05)
   model$optimize()
+  expect_equal(model_sparse$loglik, model$loglik, tolerance = 1e-2)
 })
 
 

--- a/tests/testthat/test-NB_fixed_blocks.R
+++ b/tests/testthat/test-NB_fixed_blocks.R
@@ -11,15 +11,20 @@ C <- testdata$parameters$C
 test_that("normal block with diagonal residual covariance and known clusters", {
   data <- normal_data$new(Y, X)
 
-  model <- NB_fixed_blocks$new(data, C)
+  model <- normalblockr:::NB_fixed_blocks$new(data, C)
   model$optimize()
   expect_gt(model$loglik, -2600)
   expect_lt(Metrics::rmse(model$fitted, Y), 1)
 
-  model <- NB_fixed_blocks$new(data, C, sparsity = 0.05)
+  model_sparse <- normalblockr:::NB_fixed_blocks$new(data, C, sparsity = 0.05)
+  model_sparse$optimize()
+  expect_gt(model_sparse$loglik, -2600)
+  expect_lt(Metrics::rmse(model_sparse$fitted, Y), 1)
+
+  model$sparsity <- 0.05
   model$optimize()
-  expect_gt(model$loglik, -2600)
-  expect_lt(Metrics::rmse(model$fitted, Y), 1)
+  expect_equal(model_sparse$loglik, model$loglik, tolerance = 1e-2)
+  expect_equal(model_sparse$model_par$OmegaQ, model$model_par$OmegaQ, tolerance = 1e-2)
 
 })
 


### PR DESCRIPTION
Useful to first fit model without sparsity constraint (eg when performing model selection in the number of block), and then change the sparsity level of the selected model.